### PR TITLE
Support for multiple transforms, fixes reshape/standard#40

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm i reshape-content --save
 
 ## Usage
 
-Start with some html you want to transform in some way. Add an attribute of your choosing to an element that has contents you want to transform.
+Start with some html you want to transform in some way. Add attributes of your choosing to an element that has contents you want to transform, and they will be transformed in that order.
 
 ```html
 <p windoge>Please use windows 98</p>
@@ -41,7 +41,7 @@ reshape({ plugins: content })
   .then((res) => res.output())
 ```
 
-The plugin will remove the custom attribute from the element and replace its contents with your transformed version. Wow!
+The plugin will remove the custom attributes from the element and replace its contents with your transformed version. Wow!
 
 ```html
 <p>Please use winDOGE 98</p>

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,25 +8,29 @@ module.exports = function ReshapeContent (options = {}) {
     return modifyNodes(tree, (node) => {
       // if the node doesn't have attributes, it's not what we're looking for
       if (!node.attrs) { return false }
+
       // This function cross-checks to see if any of the attribute keys match
       // any of the keys in the user config.
-      const opt = intersectKeys(options, node.attrs)[0]
       // If we get a match, add it to the node, we'll need it later
-      if (opt) { node.contentKey = opt }
-      return opt
+      node.contentKeys = intersectKeys(options, node.attrs)
+      return node.contentKeys
     }, (node) => {
-      // Grab the relevant key name
-      const key = node.contentKey
+      // Grab the relevant key names
+      const keys = node.contentKeys
 
       // Remove the attribute from the tag, it's just a marker
-      // Also remove the saved contentKey, we have it already
-      delete node.attrs[node.contentKey]
-      delete node.contentKey
+      // Also remove the saved contentKeys, we have it already
+      keys.forEach((key) => delete node.attrs[key])
+      delete node.contentKeys
 
       // Now for each entry in the node's content, we run the user-provided
-      // function, which can be a promise or not. We take the results and
+      // functions, which can be a promise or not. We take the results and
       // assign them back to the node, then return the modified node
-      return W.map(node.content, (c) => options[key](c.content)).then((res) => {
+      return W.map(node.content, (c) => {
+        let content = c.content
+        keys.forEach((key) => { content = options[key](content) })
+        return content
+      }).then((res) => {
         // TODO: the location is getting messed up here, needs an "offset"
         // option into the parser
         node.content = parser(res.join(''), {}, opts)

--- a/lib/intersectKeys.js
+++ b/lib/intersectKeys.js
@@ -1,20 +1,13 @@
-module.exports = function intersectKeys (_a, _b) {
-  let ai = 0
-  let bi = 0
-  let a = Object.keys(_a)
-  let b = Object.keys(_b)
-  const result = []
+module.exports = function intersectKeys (options, attrs) {
+  // Find matching keys
+  const matches = Object.keys(options).filter(k => k in attrs)
 
-  while (ai < a.length && bi < b.length) {
-    if (a[ai] < b[bi]) {
-      ai++
-    } else if (a[ai] > b[bi]) {
-      bi++
-    } else {
-      result.push(a[ai])
-      ai++
-      bi++
-    }
-  }
-  return result
+  // Reorder matches by order of attrs
+  let keys = []
+  Object.keys(attrs).forEach((key) => {
+    if (matches.indexOf(key) > -1) keys.push(key)
+  })
+
+  // Return found keys, or false
+  return keys.length > 0 ? keys : false
 }

--- a/test/fixtures/markdown.html
+++ b/test/fixtures/markdown.html
@@ -1,9 +1,0 @@
-<!doctype html>
-<html>
-  <head>
-    <title>Hello there!</title>
-  </head>
-  <body>
-    <p md>much **markdown**</p>
-  </body>
-</html>

--- a/test/fixtures/multiple.html
+++ b/test/fixtures/multiple.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Hello there!</title>
+  </head>
+  <body>
+    <p shorten uppercase md>**The** five boxing wizards jump quickly.</p>
+  </body>
+</html>

--- a/test/index.js
+++ b/test/index.js
@@ -45,6 +45,22 @@ test('markdown', (t) => {
     })
 })
 
+test('multiple attributes', (t) => {
+  const html = getFixture('multiple.html')
+  const markdown = MarkdownIt()
+  const plugin = content({
+    md: (ctx) => markdown.renderInline(ctx),
+    shorten: (ctx) => ctx.substr(0, 7),
+    uppercase: (ctx) => ctx.toUpperCase()
+  })
+
+  return reshape({ plugins: plugin })
+    .process(html)
+    .then((res) => {
+      t.truthy((/<p><strong>THE<\/strong><\/p>/).exec(res.output()))
+    })
+})
+
 test('postcss', (t) => {
   const html = getFixture('style.html')
   const postcss = require('postcss')([ require('postcss-nested')() ])


### PR DESCRIPTION
Happy New Year! 🎉 
With the new year comes new code.

Back over at reshape/standard#40, I'd noticed that I couldn't use markdown in tandem with another function. This led me down a rabbit hole where I found that **I couldn't use any two or more arbitrary transforms per node**, _not just markdown_.

This branch **adds support for unlimited content transforms per node**, executing in the order they appear. I've also updated the README to reflect this behaviour, eventually it would be nice to have a written example  -- _which I could/should write_.

Example:
```js
  const html = `<p shorten uppercase md>**The** five boxing wizards jump quickly.</p>`
  const markdown = MarkdownIt()
  const plugin = content({
    md: (ctx) => markdown.renderInline(ctx),
    shorten: (ctx) => ctx.substr(0, 7),
    uppercase: (ctx) => ctx.toUpperCase()
  })
  return reshape({ plugins: plugin })
    .process(html)
```
becomes:
```html
  <p><strong>THE</strong></p>
```

Pardon my ignorance if this type of functionality literally exists already, or is not intended. 
However, I find it quite handy!
Thanks! 😄 